### PR TITLE
Generate proof of existence with zero-knowledge proofs

### DIFF
--- a/deploy/kubernetes/manifests/11-orders-dep.yaml
+++ b/deploy/kubernetes/manifests/11-orders-dep.yaml
@@ -22,6 +22,8 @@ spec:
         env:
          - name: JAVA_OPTS
            value: -Xms64m -Xmx128m -XX:+UseG1GC -Djava.security.egd=file:/dev/urandom -Dspring.zipkin.enabled=false
+         - name: ZK_POE_URL
+           value: http://localhost:8088
         resources:
           limits:
             cpu: 500m
@@ -43,9 +45,72 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume
+        - mountPath: /zk
+          name: zk-artifacts
+      - name: zk-poe-sidecar
+        image: zk-poe-sidecar:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "8088"
+        - name: ZK_WASM_PATH
+          value: /zk/circuit.wasm
+        - name: ZK_ZKEY_PATH
+          value: /zk/circuit_final.zkey
+        - name: ZK_VKEY_PATH
+          value: /zk/verification_key.json
+        ports:
+        - containerPort: 8088
+          name: zk-poe
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 2
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /zk
+          name: zk-artifacts
+      initContainers:
+      - name: zk-artifacts-init
+        image: curlimages/curl:8.8.0
+        env:
+        - name: ZK_CIRCUITS_URL
+          value: "https://example.com/zk/circuits"
+        command: ["/bin/sh","-c"]
+        args:
+        - >-
+          set -eu;
+          echo "Fetching ZK artifacts from $ZK_CIRCUITS_URL";
+          mkdir -p /zk;
+          curl -fsSL "$ZK_CIRCUITS_URL/circuit.wasm" -o /zk/circuit.wasm;
+          curl -fsSL "$ZK_CIRCUITS_URL/circuit_final.zkey" -o /zk/circuit_final.zkey;
+          curl -fsSL "$ZK_CIRCUITS_URL/verification_key.json" -o /zk/verification_key.json;
+          ls -la /zk;
+        volumeMounts:
+        - mountPath: /zk
+          name: zk-artifacts
       volumes:
         - name: tmp-volume
           emptyDir:
             medium: Memory
+        - name: zk-artifacts
+          emptyDir: {}
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/zk-poe-sidecar/Dockerfile
+++ b/zk-poe-sidecar/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev && npm cache clean --force
+
+# Copy app source
+COPY . .
+
+EXPOSE 8088
+
+# Run as non-root for security
+USER node
+
+CMD ["node", "index.js"]
+

--- a/zk-poe-sidecar/README.md
+++ b/zk-poe-sidecar/README.md
@@ -1,0 +1,34 @@
+# zk-poe-sidecar
+
+HTTP sidecar for generating and verifying Groth16 proofs with snarkjs.
+
+## Endpoints
+
+- POST `/prove`
+  - Body: `{ "input": { ... }, "wasmPath?": "/zk/circuit.wasm", "zkeyPath?": "/zk/circuit_final.zkey" }`
+  - Response: `{ proof, publicSignals }`
+
+- POST `/verify`
+  - Body: `{ proof, publicSignals, "vkeyPath?": "/zk/verification_key.json" }`
+  - Response: `{ valid: true|false }`
+
+- GET `/healthz`
+
+## Environment
+
+- `PORT` (default: `8088`)
+- `ZK_WASM_PATH` (default: `/zk/circuit.wasm`)
+- `ZK_ZKEY_PATH` (default: `/zk/circuit_final.zkey`)
+- `ZK_VKEY_PATH` (default: `/zk/verification_key.json`)
+
+Artifacts should be mounted at `/zk` via a shared volume. An initContainer can download them from `ZK_CIRCUITS_URL` into `/zk`.
+
+## Docker
+
+Build and run locally:
+
+```bash
+docker build -t zk-poe-sidecar:latest ./zk-poe-sidecar
+docker run --rm -p 8088:8088 -v "$PWD/circuits:/zk:ro" zk-poe-sidecar:latest
+```
+

--- a/zk-poe-sidecar/index.js
+++ b/zk-poe-sidecar/index.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+const { groth16 } = require("snarkjs");
+
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 8088;
+const DEFAULT_WASM_PATH = process.env.ZK_WASM_PATH || "/zk/circuit.wasm";
+const DEFAULT_ZKEY_PATH = process.env.ZK_ZKEY_PATH || "/zk/circuit_final.zkey";
+const DEFAULT_VKEY_PATH = process.env.ZK_VKEY_PATH || "/zk/verification_key.json";
+
+function assertFileReadable(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    const err = new Error(`File not found: ${resolvedPath}`);
+    err.statusCode = 400;
+    throw err;
+  }
+  fs.accessSync(resolvedPath, fs.constants.R_OK);
+  return resolvedPath;
+}
+
+app.get("/healthz", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
+app.post("/prove", async (req, res) => {
+  try {
+    const input = req.body && req.body.input;
+    if (!input || typeof input !== "object") {
+      return res.status(400).json({ error: "Missing or invalid 'input' in body" });
+    }
+
+    const wasmPath = assertFileReadable(req.body.wasmPath || DEFAULT_WASM_PATH);
+    const zkeyPath = assertFileReadable(req.body.zkeyPath || DEFAULT_ZKEY_PATH);
+
+    const { proof, publicSignals } = await groth16.fullProve(input, wasmPath, zkeyPath);
+    return res.status(200).json({ proof, publicSignals });
+  } catch (error) {
+    const status = error && error.statusCode ? error.statusCode : 500;
+    return res.status(status).json({ error: error.message || String(error) });
+  }
+});
+
+app.post("/verify", async (req, res) => {
+  try {
+    const { proof, publicSignals } = req.body || {};
+    if (!proof || !publicSignals) {
+      return res.status(400).json({ error: "Missing 'proof' or 'publicSignals' in body" });
+    }
+
+    const vkeyPath = assertFileReadable(req.body.vkeyPath || DEFAULT_VKEY_PATH);
+    const vKey = JSON.parse(fs.readFileSync(vkeyPath, "utf8"));
+    const ok = await groth16.verify(vKey, publicSignals, proof);
+    return res.status(200).json({ valid: Boolean(ok) });
+  } catch (error) {
+    const status = error && error.statusCode ? error.statusCode : 500;
+    return res.status(status).json({ error: error.message || String(error) });
+  }
+});
+
+app.use((err, _req, res, _next) => {
+  const status = err && err.statusCode ? err.statusCode : 500;
+  res.status(status).json({ error: err.message || String(err) });
+});
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`zk-poe-sidecar listening on ${PORT}`);
+});
+

--- a/zk-poe-sidecar/package.json
+++ b/zk-poe-sidecar/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zk-poe-sidecar",
+  "version": "0.1.0",
+  "description": "Sidecar service to generate and verify PoE using Groth16 (snarkjs)",
+  "private": true,
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "NODE_ENV=development node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "snarkjs": "^0.7.3"
+  }
+}


### PR DESCRIPTION
- A description of the changes proposed in the pull request

This PR introduces a `zk-poe-sidecar` container to the `orders` Kubernetes Deployment. This sidecar, implemented as a Node.js service using `snarkjs`, provides HTTP endpoints for generating and verifying Groth16 Zero-Knowledge Proofs of Existence (PoE).

An `initContainer` is included to fetch ZKP circuit artifacts (wasm, zkey, vkey) from a configurable URL into a shared volume, making them accessible to the sidecar. The `orders` service is updated with an environment variable (`ZK_POE_URL`) to facilitate communication with the sidecar.

This change enables the `orders` service to leverage ZKP capabilities directly for generating PoEs from its data and requests, without embedding ZKP logic within the main application.

---
<a href="https://cursor.com/background-agent?bcId=bc-8243bf50-27f7-43ac-853d-3e88dc0df791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8243bf50-27f7-43ac-853d-3e88dc0df791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

