### PR TITLE
Create payment service sidecar container

### DIFF
--- a/deploy/kubernetes/complete-demo.yaml
+++ b/deploy/kubernetes/complete-demo.yaml
@@ -493,6 +493,23 @@ spec:
             port: 80
           initialDelaySeconds: 180
           periodSeconds: 3
+      - name: payment-sidecar
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - while true; do wget -qO- http://127.0.0.1:80/health || true; sleep 10; done
+        resources:
+          limits:
+            cpu: 20m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux
 ---

--- a/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
+++ b/deploy/kubernetes/helm-chart/templates/payment-dep.yaml
@@ -57,3 +57,17 @@ spec:
             port: {{ .Values.payment.containerPort }}
           initialDelaySeconds: 180
           periodSeconds: 3
+      {{- if .Values.payment.sidecar.enabled }}
+      - name: payment-sidecar
+        image: {{if .Values.global.registry}}{{ .Values.global.registry }}/{{end}}{{ .Values.payment.sidecar.image }}:{{ .Values.payment.sidecar.tag }}
+        command:
+        - sh
+        - -c
+        - while true; do wget -qO- http://127.0.0.1:{{ .Values.payment.containerPort }}/health || true; sleep {{ .Values.payment.sidecar.intervalSeconds }}; done
+        resources:
+{{ toYaml .Values.payment.sidecar.resources | indent 10 }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          readOnlyRootFilesystem: true
+      {{- end }}

--- a/deploy/kubernetes/helm-chart/values.yaml
+++ b/deploy/kubernetes/helm-chart/values.yaml
@@ -138,6 +138,18 @@ payment:
         requests:
             cpu: 100m
             memory: 100Mi
+    sidecar:
+        enabled: true
+        image: busybox
+        tag: 1.36
+        intervalSeconds: 10
+        resources:
+            limits:
+                cpu: 20m
+                memory: 32Mi
+            requests:
+                cpu: 5m
+                memory: 16Mi
 
 queuemaster:
     image:

--- a/deploy/kubernetes/manifests-jaeger/payment-dep.yaml
+++ b/deploy/kubernetes/manifests-jaeger/payment-dep.yaml
@@ -52,5 +52,22 @@ spec:
             port: 80
           initialDelaySeconds: 180
           periodSeconds: 3
+      - name: payment-sidecar
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - while true; do wget -qO- http://127.0.0.1:80/health || true; sleep 10; done
+        resources:
+          limits:
+            cpu: 20m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deploy/kubernetes/manifests/15-payment-dep.yaml
+++ b/deploy/kubernetes/manifests/15-payment-dep.yaml
@@ -49,5 +49,22 @@ spec:
             port: 80
           initialDelaySeconds: 180
           periodSeconds: 3
+      - name: payment-sidecar
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - while true; do wget -qO- http://127.0.0.1:80/health || true; sleep 10; done
+        resources:
+          limits:
+            cpu: 20m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 10001
+          readOnlyRootFilesystem: true
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
- Read the contribution guidelines
- Include a reference to a related issue in this repository: N/A
- A description of the changes proposed in the pull request:
Adds a `busybox` sidecar container to the Payment service deployments for basic health monitoring. The sidecar periodically pings the `/health` endpoint of the Payment service.

Changes include:
-   Adding the sidecar to plain Kubernetes manifests (`15-payment-dep.yaml`, `complete-demo.yaml`, `manifests-jaeger/payment-dep.yaml`).
-   Integrating a configurable sidecar into the Helm chart (`payment-dep.yaml` template and `values.yaml`), enabled by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-da5bd4bd-60f8-4505-b9df-a4282af3259f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da5bd4bd-60f8-4505-b9df-a4282af3259f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

